### PR TITLE
Coupling rule is misconfigured 

### DIFF
--- a/modules/prbot/src/main/resources/pmd_rules.xml
+++ b/modules/prbot/src/main/resources/pmd_rules.xml
@@ -12,9 +12,6 @@
     <rule ref="rulesets/java/braces.xml" />
     <rule ref="rulesets/java/codesize.xml" />
 
-    <rule ref="rulesets/java/coupling.xml" >
-         <exclude name="LawOfDemeter" />
-    </rule>
     <rule ref="rulesets/java/design.xml" />
     <rule ref="rulesets/java/empty.xml" />
     <rule ref="rulesets/java/imports.xml" />


### PR DESCRIPTION
looks like [one needs to specify either class or package](http://pmd.sourceforge.net/snapshot/xref/net/sourceforge/pmd/lang/java/rule/coupling/LoosePackageCouplingRule.html)

dropping it, as it's ignored anyways: 

```
WARNING: Removed misconfigured rule: LoosePackageCoupling  cause: No packages or classes specified
```
