### PR TITLE
Alternative implementation of PMD executor (scalish, testeable)

### DIFF
--- a/modules/prbot/src/main/scala/ru/bugzmanov/prcheck/checks/JavaPmdExecutor.scala
+++ b/modules/prbot/src/main/scala/ru/bugzmanov/prcheck/checks/JavaPmdExecutor.scala
@@ -14,7 +14,7 @@ import scala.util.{Failure, Success, Try}
 
 @NotThreadSafe
 class JavaPmdExecutor private (config: PMDConfiguration) {
-  val BlacklistedRules = Set("LawOfDemeter", "LongVariable", "AbstractNaming", "JUnitTestsShouldIncludeAssert", "JUnitSpelling")
+  val BlacklistedRules = Set("LongVariable", "AbstractNaming", "JUnitTestsShouldIncludeAssert", "JUnitSpelling")
   val ruleSetFactory = new RuleSetFactory
   val processor = new SourceCodeProcessor(config)
   val rules = RulesetsFactoryUtils.getRuleSets(config.getRuleSets, ruleSetFactory)

--- a/modules/prbot/src/main/scala/ru/bugzmanov/prcheck/checks/JavaPmdExecutor.scala
+++ b/modules/prbot/src/main/scala/ru/bugzmanov/prcheck/checks/JavaPmdExecutor.scala
@@ -23,7 +23,8 @@ class JavaPmdExecutor private (config: PMDConfiguration) {
     val report: Report = process(source)
 
     if (report.hasConfigErrors) {
-      Failure(???)
+      val errors = report.configErrors().asScala.mkString("{", ", ", "}")
+      Failure(new IllegalArgumentException(s"Configuration errors: $errors"))
     } else if(report.hasErrors) {
       Failure(???)
     } else {

--- a/modules/prbot/src/main/scala/ru/bugzmanov/prcheck/checks/JavaPmdExecutor.scala
+++ b/modules/prbot/src/main/scala/ru/bugzmanov/prcheck/checks/JavaPmdExecutor.scala
@@ -1,0 +1,75 @@
+package ru.bugzmanov.prcheck.checks
+
+import java.io.BufferedInputStream
+
+import net.sourceforge.pmd._
+import net.sourceforge.pmd.lang.Language
+import net.sourceforge.pmd.lang.java.JavaLanguageModule
+import net.sourceforge.pmd.util.datasource.DataSource
+
+import scala.util.{Success, Try}
+
+class JavaPmdExecutor private (config: PMDConfiguration) {
+  val BlacklistedRules = Set("LawOfDemeter", "LongVariable", "AbstractNaming", "JUnitTestsShouldIncludeAssert", "JUnitSpelling")
+  val ruleSetFactory = new RuleSetFactory
+  val processor = new SourceCodeProcessor(config)
+  val rules = RulesetsFactoryUtils.getRuleSets(config.getRuleSets, ruleSetFactory)
+
+  def process(sources: DataSource*): Try[Iterable[ViolationIssue]] = {
+    val reports = analyze(sources)
+    val issues = reports.flatMap { report => JavaPmdExecutor.asList(report.iterator()) }.map(JavaPmdExecutor.asIssue)
+
+    val filtered = issues
+      .filterNot(isTestFile)
+      .filterNot(issue => BlacklistedRules.contains(issue.rule))
+
+    Success(filtered)
+  }
+
+  def isTestFile(vi: ViolationIssue) = vi.file.contains("src/test")
+
+  private def analyze(sources: Iterable[DataSource]): Iterable[Report] = {
+    val ctx = new RuleContext
+    ctx.setLanguageVersion(null)
+
+    sources.map { source =>
+      val niceName = source.getNiceFileName(config.isReportShortNames, config.getInputPaths)
+      val report = PMD.setupReport(rules, ctx, niceName)
+      val bis = new BufferedInputStream(source.getInputStream)
+      rules.start(ctx)
+      processor.processSourceCode(bis, rules, ctx)
+      rules.end(ctx)
+      report
+    }
+  }
+  
+}
+
+object JavaPmdExecutor {
+  private[JavaPmdExecutor] final val langs: Set[Language] = Set(new JavaLanguageModule)
+
+  private[JavaPmdExecutor] def asList[T](it: java.util.Iterator[T], acc: List[T] = Nil): List[T] = {
+    if (it.hasNext) {
+      asList(it, it.next::acc)
+    } else {
+      acc
+    }
+  }
+
+  private[JavaPmdExecutor] def asIssue(violation: RuleViolation): ViolationIssue = ViolationIssue(
+    classPackage = violation.getPackageName,
+    file = violation.getFilename,
+    priority = violation.getRule.getPriority.getPriority,
+    line = violation.getBeginLine,
+    description = violation.getDescription,
+    ruleSet = violation.getRule.getRuleSetName,
+    rule = violation.getRule.getName,
+    tag = "pmd"
+  )
+
+  def fromRulesFile(classpath: String): JavaPmdExecutor = {
+    val config = new PMDConfiguration
+    config.setRuleSets(classpath)
+    new JavaPmdExecutor(config)
+  }
+}

--- a/modules/prbot/src/main/scala/ru/bugzmanov/prcheck/checks/JavaPmdExecutor.scala
+++ b/modules/prbot/src/main/scala/ru/bugzmanov/prcheck/checks/JavaPmdExecutor.scala
@@ -1,6 +1,7 @@
 package ru.bugzmanov.prcheck.checks
 
 import java.io.BufferedInputStream
+import javax.annotation.concurrent.NotThreadSafe
 
 import net.sourceforge.pmd._
 import net.sourceforge.pmd.lang.Language
@@ -9,6 +10,7 @@ import net.sourceforge.pmd.util.datasource.DataSource
 
 import scala.util.{Success, Try}
 
+@NotThreadSafe
 class JavaPmdExecutor private (config: PMDConfiguration) {
   val BlacklistedRules = Set("LawOfDemeter", "LongVariable", "AbstractNaming", "JUnitTestsShouldIncludeAssert", "JUnitSpelling")
   val ruleSetFactory = new RuleSetFactory

--- a/modules/prbot/src/test/resources/broken_rules.xml
+++ b/modules/prbot/src/test/resources/broken_rules.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         name="Android Application Rules"
+         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd"
+         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd">
+
+    <description>Broken LawOfDemeter rule</description>
+
+    <rule ref="rulesets/java/coupling.xml">
+        <exclude name="LawOfDemeter"/>
+    </rule>
+</ruleset>

--- a/modules/prbot/src/test/resources/only_logging_rule.xml
+++ b/modules/prbot/src/test/resources/only_logging_rule.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         name="Android Application Rules"
+         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd"
+         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd" >
+    <rule ref="rulesets/java/logging-java.xml"/>
+</ruleset>

--- a/modules/prbot/src/test/scala/ru/bugzmanov/prcheck/checks/PmdExecutorSpec.scala
+++ b/modules/prbot/src/test/scala/ru/bugzmanov/prcheck/checks/PmdExecutorSpec.scala
@@ -48,7 +48,10 @@ class PmdExecutorSpec extends FlatSpec {
     val issues = executor.process(fromString(GoodHelloWorldCode)).get
     issues shouldBe empty
   }
-
+  it should "correctly process multiple files at once" in {
+    val issues = executor.process(fromString(BadHelloWorldCode), fromString(GoodHelloWorldCode)).get
+    issues.map(_.rule) should contain theSameElementsAs HelloWorldIssues
+  }
 }
 
 object AsDataSource {

--- a/modules/prbot/src/test/scala/ru/bugzmanov/prcheck/checks/PmdExecutorSpec.scala
+++ b/modules/prbot/src/test/scala/ru/bugzmanov/prcheck/checks/PmdExecutorSpec.scala
@@ -60,6 +60,11 @@ class PmdExecutorSpec extends FlatSpec with TryValues {
     val issues = executor.analyze(GoodHelloWorldCode).success.value
     issues shouldBe empty
   }
+  it should "report only issues mentioned in xml config" in {
+    val executor = JavaPmdExecutor.fromRulesFile("only_logging_rule.xml")
+    val issues = executor.analyze(BadHelloWorldCode).success.value
+    issues.map(_.rule) should equal (Seq("SystemPrintln"))
+  }
   it should "correctly process multiple files at once" in {
     val executor = JavaPmdExecutor.fromRulesFile("pmd_rules.xml")
     val issues = executor.analyze(BadHelloWorldCode).success.value

--- a/modules/prbot/src/test/scala/ru/bugzmanov/prcheck/checks/PmdExecutorSpec.scala
+++ b/modules/prbot/src/test/scala/ru/bugzmanov/prcheck/checks/PmdExecutorSpec.scala
@@ -41,6 +41,14 @@ class PmdExecutorSpec extends FlatSpec with TryValues {
       """.stripMargin
   )
 
+  val UnparseableCode = fromString(
+    name = "unparseable",
+    contents =
+      """
+        | blah blah
+      """.stripMargin
+  )
+
 
   "Pmd suite" should "report issues for problematic version of 'Hello world'" in {
     val executor = JavaPmdExecutor.fromRulesFile("pmd_rules.xml")
@@ -67,6 +75,15 @@ class PmdExecutorSpec extends FlatSpec with TryValues {
     failure.exception match {
       case ex: IllegalArgumentException => ex.getMessage should startWith("Configuration errors:")
       case _ => fail("Expected IAS for misconfigured rules file")
+    }
+  }
+  it should "throw IllegalStateException in case of processing errors" in {
+    val executor = JavaPmdExecutor.fromRulesFile("pmd_rules.xml")
+    val failure = executor.analyze(UnparseableCode).failure
+
+    failure.exception match {
+      case ex: IllegalStateException => ex.getMessage should startWith("Caught error(s) during processing: ")
+      case _ => fail("Expected RuntimeException for unparseable files")
     }
   }
 }

--- a/modules/prbot/src/test/scala/ru/bugzmanov/prcheck/checks/PmdExecutorSpec.scala
+++ b/modules/prbot/src/test/scala/ru/bugzmanov/prcheck/checks/PmdExecutorSpec.scala
@@ -44,15 +44,18 @@ class PmdExecutorSpec extends FlatSpec {
 
 
   "Pmd suite" should "report issues for problematic version of 'Hello world'" in {
-    val issues = executor.process(BadHelloWorldCode).get
+    val issues = executor.analyze(BadHelloWorldCode).get
     issues.map(_.rule) should contain theSameElementsAs HelloWorldIssues
   }
   it should "remain silent for linted version of 'Hello world'" in {
-    val issues = executor.process(GoodHelloWorldCode).get
+    val issues = executor.analyze(GoodHelloWorldCode).get
     issues shouldBe empty
   }
   it should "correctly process multiple files at once" in {
-    val issues = executor.process(BadHelloWorldCode, GoodHelloWorldCode).get
+    val issues = executor.analyze(BadHelloWorldCode).get
+    val noIssues = executor.analyze(GoodHelloWorldCode).get
+
+    noIssues shouldBe empty
     issues.map(_.rule) should contain theSameElementsAs HelloWorldIssues
   }
 }

--- a/modules/prbot/src/test/scala/ru/bugzmanov/prcheck/checks/PmdExecutorSpec.scala
+++ b/modules/prbot/src/test/scala/ru/bugzmanov/prcheck/checks/PmdExecutorSpec.scala
@@ -13,19 +13,22 @@ class PmdExecutorSpec extends FlatSpec {
   val HelloWorldIssues = Seq("UseUtilityClass", "UseVarargs", "SystemPrintln", "NoPackage")
   val executor = JavaPmdExecutor.fromRulesFile("pmd_rules.xml")
 
-  val BadHelloWorldCode =
-    """
-      |public class HelloWorld {
-      |
-      |    public static void main(String[] args) {
-      |        System.out.println("Hello, World");
-      |    }
-      |
-      |}
-    """.stripMargin
+  val BadHelloWorldCode = fromString(
+    name = "bad-hello-word",
+    contents = """
+    |public class HelloWorld {
+    |
+    |    public static void main(String[] args) {
+    |        System.out.println("Hello, World");
+    |    }
+    |}
+    |""".stripMargin
+  )
 
-  val GoodHelloWorldCode =
-    """
+  val GoodHelloWorldCode = fromString(
+    name = "good-hello-world",
+    contents =
+      """
       |package foo.bar;
       |
       |public final class HelloWorld {
@@ -35,29 +38,29 @@ class PmdExecutorSpec extends FlatSpec {
       |    public static void main(String ... args) {
       |        log.info("Hello, World");
       |    }
-      |
       |}
-    """.stripMargin
+      """.stripMargin
+  )
 
 
   "Pmd suite" should "report issues for problematic version of 'Hello world'" in {
-    val issues = executor.process(fromString(BadHelloWorldCode)).get
+    val issues = executor.process(BadHelloWorldCode).get
     issues.map(_.rule) should contain theSameElementsAs HelloWorldIssues
   }
   it should "remain silent for linted version of 'Hello world'" in {
-    val issues = executor.process(fromString(GoodHelloWorldCode)).get
+    val issues = executor.process(GoodHelloWorldCode).get
     issues shouldBe empty
   }
   it should "correctly process multiple files at once" in {
-    val issues = executor.process(fromString(BadHelloWorldCode), fromString(GoodHelloWorldCode)).get
+    val issues = executor.process(BadHelloWorldCode, GoodHelloWorldCode).get
     issues.map(_.rule) should contain theSameElementsAs HelloWorldIssues
   }
 }
 
 object AsDataSource {
   private final val Utf8 = Charset.forName("UTF-8")
-  def fromString(str: String): DataSource = new DataSource {
-    override def getNiceFileName(shortNames: Boolean, inputFileName: String): String = "made-from-string"
-    override def getInputStream: InputStream = new ByteArrayInputStream(str.getBytes(Utf8))
+  def fromString(name: String, contents: String): DataSource = new DataSource {
+    override def getNiceFileName(shortNames: Boolean, inputFileName: String): String = name
+    override def getInputStream: InputStream = new ByteArrayInputStream(contents.getBytes(Utf8))
   }
 }

--- a/modules/prbot/src/test/scala/ru/bugzmanov/prcheck/checks/PmdExecutorSpec.scala
+++ b/modules/prbot/src/test/scala/ru/bugzmanov/prcheck/checks/PmdExecutorSpec.scala
@@ -9,7 +9,7 @@ import org.scalatest.Matchers._
 
 
 class PmdExecutorSpec extends FlatSpec {
-  import AsDataSource.fromString
+  import StringDataSource.fromString
   val HelloWorldIssues = Seq("UseUtilityClass", "UseVarargs", "SystemPrintln", "NoPackage")
   val executor = JavaPmdExecutor.fromRulesFile("pmd_rules.xml")
 
@@ -22,7 +22,7 @@ class PmdExecutorSpec extends FlatSpec {
     |        System.out.println("Hello, World");
     |    }
     |}
-    |""".stripMargin
+    """.stripMargin
   )
 
   val GoodHelloWorldCode = fromString(
@@ -57,7 +57,7 @@ class PmdExecutorSpec extends FlatSpec {
   }
 }
 
-object AsDataSource {
+private object StringDataSource {
   private final val Utf8 = Charset.forName("UTF-8")
   def fromString(name: String, contents: String): DataSource = new DataSource {
     override def getNiceFileName(shortNames: Boolean, inputFileName: String): String = name

--- a/modules/prbot/src/test/scala/ru/bugzmanov/prcheck/checks/PmdExecutorSpec.scala
+++ b/modules/prbot/src/test/scala/ru/bugzmanov/prcheck/checks/PmdExecutorSpec.scala
@@ -1,0 +1,41 @@
+package ru.bugzmanov.prcheck.checks
+
+import java.io.{ByteArrayInputStream, InputStream}
+import java.nio.charset.Charset
+
+import net.sourceforge.pmd.util.datasource.DataSource
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers._
+
+
+class PmdExecutorSpec extends FlatSpec {
+  val HelloWorldCode =
+    """
+      |public class HelloWorld {
+      |
+      |    public static void main(String[] args) {
+      |        System.out.println("Hello, World");
+      |    }
+      |
+      |}
+    """.stripMargin
+
+  val HelloWorldIssues = Seq("UseUtilityClass", "UseVarargs", "SystemPrintln", "NoPackage")
+  val executor = JavaPmdExecutor.fromRulesFile("pmd_rules.xml")
+
+  "Pmd suite" should s"report issues for 'Hello world' code piece" in {
+    val issues = executor.process(AsDataSource.fromString(HelloWorldCode)).get
+    issues.map(_.rule) should contain theSameElementsAs HelloWorldIssues
+  }
+  ignore should "yield errors if file is missing" in {
+
+  }
+}
+
+object AsDataSource {
+  private final val Utf8 = Charset.forName("UTF-8")
+  def fromString(str: String): DataSource = new DataSource {
+    override def getNiceFileName(shortNames: Boolean, inputFileName: String): String = "made-from-string"
+    override def getInputStream: InputStream = new ByteArrayInputStream(str.getBytes(Utf8))
+  }
+}


### PR DESCRIPTION
Not switching to it yet -- if you're happy with the approach, I will add error handling (misconfiguration, unparseable files, properly closing bis in case of failure) and more tests first.
